### PR TITLE
Fix #1 - remove strange < 12 and < 12 logic

### DIFF
--- a/korexo_profile/korexo.py
+++ b/korexo_profile/korexo.py
@@ -157,9 +157,9 @@ def _read_korexo_format(fn, encoding, parse_dts=True, datefmt="auto"):
                                 datefmt = "%d/%m/%Y"
                             elif unitfmt == "DD/MM/YYYY" and int(second) > 12:
                                 datefmt = "%m/%d/%Y"
-                            elif int(first) <= 12 and int(second) <= 12:
-                                if unitfmt == "MM/DD/YYYY" and second.startswith("0"):
-                                    datefmt = "%d/%m/%Y"
+                            # elif int(first) <= 12 and int(second) <= 12:
+                            #     if unitfmt == "MM/DD/YYYY" and second.startswith("0"):
+                            #         datefmt = "%d/%m/%Y"
                             else:
                                 pass
                     try:


### PR DESCRIPTION
This results in datefmt="auto" only force-changing the date format when we know for a fact it is wrong
i.e. month > 12